### PR TITLE
Use official WinAppCli setup action instead of manual install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,7 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     - name: Install winapp CLI
-      run: |
-        dotnet tool install --global Microsoft.WinAppCli
-      shell: pwsh
+      uses: microsoft/setup-WinAppCli@v1
 
     - name: Restore the application
       run: dotnet restore $env:Project_Path


### PR DESCRIPTION
## Summary
Replaced the manual `dotnet tool install` command with the official Microsoft `setup-WinAppCli` GitHub Action for installing the WinApp CLI tool in the release workflow.

## Key Changes
- Replaced inline `dotnet tool install --global Microsoft.WinAppCli` command with `microsoft/setup-WinAppCli@v1` action
- Removed explicit `shell: pwsh` specification (handled by the action)
- Simplified the workflow step by using the official setup action

## Benefits
- Uses the officially maintained action from Microsoft for better reliability and support
- Reduces maintenance burden by delegating CLI setup to the dedicated action
- Cleaner workflow configuration with less boilerplate

https://claude.ai/code/session_01GAgUUeqs69PLz5eKg595pU