### PR TITLE
Downgrade WinAppCli setup action to v0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     - name: Install winapp CLI
-      uses: microsoft/setup-WinAppCli@v1
+      uses: microsoft/setup-WinAppCli@v0.1
 
     - name: Restore the application
       run: dotnet restore $env:Project_Path


### PR DESCRIPTION
## Summary
Updated the Microsoft WinAppCli setup action version in the release workflow from v1 to v0.1.

## Changes
- Downgraded `microsoft/setup-WinAppCli` action from v1 to v0.1 in the release workflow

## Details
This change modifies the GitHub Actions workflow used for releases to use an earlier version of the WinAppCli setup action. This may be necessary to resolve compatibility issues or to use a more stable version of the action for the release process.

https://claude.ai/code/session_01GAgUUeqs69PLz5eKg595pU