### PR TITLE
Fix ~1s input lag after opening the search overlay

### DIFF
--- a/quickLink/MainWindow.xaml.cs
+++ b/quickLink/MainWindow.xaml.cs
@@ -414,10 +414,19 @@ namespace quickLink
                 RootGrid.Opacity = 0;
                 SearchBox.Text = string.Empty;
 
-                DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
+                // Focus immediately so keystrokes register the moment the window appears.
+                SearchBox.Focus(FocusState.Programmatic);
+                SearchBox.SelectAll();
+
+                // Uncloak + animate after the current render batch. This used to run at
+                // DispatcherQueuePriority.Low, which gets starved by show-time layout/filter
+                // work — leaving the window cloaked and unfocused for ~1s, so typing didn't
+                // register on almost every open. Normal priority can't be starved that way.
+                DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Normal, () =>
                 {
                     try { DwmInterop.Uncloak(_windowHandle); } catch { /* non-fatal */ }
                     WindowEnterAnimation.Begin();
+                    // Re-focus in case the immediate focus above lost the race with activation.
                     SearchBox.Focus(FocusState.Programmatic);
                     SearchBox.SelectAll();
                 });


### PR DESCRIPTION
## Problem
On almost every open, the search overlay appears but **you can't type for ~1 second** — keystrokes are lost until the lag clears.

## Cause
In `OnGlobalHotkeyPressed` (`MainWindow.xaml.cs`), the overlay is DWM-cloaked on show and then **uncloaked + focused only on a `DispatcherQueuePriority.Low` dispatcher tick**. `Low` priority runs only when the UI thread has no higher-priority work, but every show kicks off a burst of layout + filter work that **starves that tick for ~1s**. During that gap the search box never receives focus, so typing doesn't register.

## Fix
- **Focus the search box immediately** on show instead of waiting for the starvable tick — keystrokes register the moment the window appears.
- **Moved the uncloak/animation to `Normal` priority** so the visual reveal can't be starved either, with a re-focus as a safety net.

Small, contained change to that one method.

## Testing
⚠️ Not verified on a real machine (built/tested in a Linux container without WinUI). Please confirm on Windows:
1. Typing works immediately on open (no ~1s dead period).
2. No white/blank flash when the window appears.

If a flash appears, a more conservative variant (uncloak on the first composed frame via `CompositionTarget.Rendering`) is ready to swap in.

https://claude.ai/code/session_01SecuS7h86UFzXWr8dBHeqc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SecuS7h86UFzXWr8dBHeqc)_